### PR TITLE
prevent lost identity

### DIFF
--- a/docs/developer/node/general.md
+++ b/docs/developer/node/general.md
@@ -32,7 +32,7 @@ To connect to Idena `experimental mainnet` network run executable without parame
 Custom json configuration can be used if `--config=<config file name>` parameter is specified. Use `server` IPFS profile if you run `idena-go` on VPS to prevent local network scanning.
 ```json
 {
-  "DataDir": "",
+  "DataDir": "datadir",
   "P2P": {
     "MaxInboundPeers": 12,
     "MaxOutboundPeers": 6


### PR DESCRIPTION
If "DataDir" is left empty, node will not make nodekey file, and after node restart, person will lose his identity. Some people have taken this sample to create their config file and have lost identites. I have tested and confirmed this on Linux.